### PR TITLE
Add missing use statement

### DIFF
--- a/config.php.sample
+++ b/config.php.sample
@@ -1,4 +1,7 @@
 <?php
+
+use Laminas\Mail\Transport\SmtpOptions;
+
 // E-mail address applied as standard FROM-address and system message recipient. Notice: Some picky providers demand a dedicated address here (MX with the respective domain or other prerequisites);
    $mymail='enteryour@email.here.in.config.php';
 


### PR DESCRIPTION
The script was missing the use statement for the SmtpOptions class. The
config.php on the testserver had this line but the transfer to the
sample script got forgotten.

Fixes #7
