### PR TITLE
Make some code points involving cookies more robust

### DIFF
--- a/acceptlanguage.php
+++ b/acceptlanguage.php
@@ -1,5 +1,6 @@
-<?php 
+<?php
+
 echo $_SERVER['HTTP_ACCEPT_LANGUAGE'];
 echo '<hr>';
-echo $_COOKIE['aclan'];
-?>
+echo $_COOKIE['aclan'] ?? 'Cookie "aclan" is not set';
+

--- a/ft.idn.inc.inc.php
+++ b/ft.idn.inc.inc.php
@@ -17,8 +17,8 @@
     $passwd = $concatlogins;
 
     if ($usesessioninsteadofbasicauth != 'no') {
-        $_SERVER['PHP_AUTH_USER'] = $_COOKIE['u'];
-        $_SERVER['PHP_AUTH_PW'] = $_COOKIE['p'];
+        $_SERVER['PHP_AUTH_USER'] = $_COOKIE['u'] ?? '';
+        $_SERVER['PHP_AUTH_PW'] = $_COOKIE['p'] ?? '';
     }
     $_SERVER['PHP_AUTH_USER'] = trim($_SERVER['PHP_AUTH_USER']);
     $_SERVER['PHP_AUTH_PW'] = trim($_SERVER['PHP_AUTH_PW']);

--- a/u5admin/delete.php
+++ b/u5admin/delete.php
@@ -1,4 +1,7 @@
-<?php 
-if ($_COOKIE['dora']=='a') header("Location: archiveunarchive.php?".$_SERVER['QUERY_STRING']);
-else header("Location: deleteanitem.php?".$_SERVER['QUERY_STRING']);
-?>
+<?php
+
+if (isset($_COOKIE['dora']) && $_COOKIE['dora']=='a') {
+    header("Location: archiveunarchive.php?".$_SERVER['QUERY_STRING']);
+} else {
+    header("Location: deleteanitem.php?".$_SERVER['QUERY_STRING']);
+}

--- a/u5admin/s.php
+++ b/u5admin/s.php
@@ -1,11 +1,9 @@
 <?php
 
-if (isset($_COOKIE['subs'])) {
-    if ($_COOKIE['subs']=='s2') {
-        header("Location: s2.php");
-    } else {
-        header("Location: c.php");
-    }
+if (isset($_COOKIE['subs']) && $_COOKIE['subs']=='s2') {
+    header("Location: s2.php");
+} elseif (isset($_COOKIE['subs']) && $_COOKIE['subs']=='s3') {
+    header("Location: c.php");
 } else {
     header("Location: s1.php");
 }

--- a/u5admin/s2_x.php
+++ b/u5admin/s2_x.php
@@ -1,5 +1,9 @@
-<?php 
-if ($_COOKIE['subs']=='s2') header("Location: s2.php");
-else if ($_COOKIE['subs']=='s3') header("Location: c.php");
-else header("Location: s1.php");
-?>
+<?php
+
+if (isset($_COOKIE['subs']) && $_COOKIE['subs']=='s2') {
+    header("Location: s2.php");
+} elseif (isset($_COOKIE['subs']) && $_COOKIE['subs']=='s3') {
+    header("Location: c.php");
+} else {
+    header("Location: s1.php");
+}


### PR DESCRIPTION
These code places lead to errors previously. In addition the usage of the
coalescing operator available since PHP 7 is introduced at two
convenient places illustrate its usage.

Fixes #13, #15
