### PR TITLE
Purge old lib directory

### DIFF
--- a/r/runonce.php
+++ b/r/runonce.php
@@ -369,6 +369,7 @@ file_put_contents('../config.php',$configphp);
    } 
  }
 rrmdir('../fancybox');
+rrmdir('../lib');
 unlink('../v.js');
 unlink('../c.js');
 ?>


### PR DESCRIPTION
The previous versions of the u5cms were featuring Zend modules available
in the lib/ subdirectory at toplevel. In terms of housekeeping, this
subdirectory can be safely and automatically deleted when updating to any
relase 10.x.

Fixes #20
