### PR TITLE
Fix char encoding issue with get param in mailing

### DIFF
--- a/u5admin/mailinglist.php
+++ b/u5admin/mailinglist.php
@@ -8,7 +8,7 @@
 <script>
 document.write('<!--'+unescape(location.href)+'-->');
 </script>
-<button onclick="cf=prompt('Beginning a new mailjob. Please enter the subject (may be changed later):','');if(cf)location.replace('mailnew.php?y='+cf+'&n=<?php echo $_GET['n']?>&t=<?php echo $_GET['t'] ?>')">new mailjob &#19904;</button>
+<button onclick="cf=prompt('Beginning a new mailjob. Please enter the subject (may be changed later):','');if(cf)location.replace('mailnew.php?y='+encodeURIComponent(cf)+'&n=<?php echo $_GET['n']?>&t=<?php echo $_GET['t'] ?>')">new mailjob &#19904;</button>
 <?php 
 $sql_a="SELECT * FROM mailing WHERE maildeleted=0 ORDER BY id DESC";
 $result_a=mysql_query($sql_a);
@@ -19,7 +19,9 @@ echo 'SQL_a-Query failed!<p>'.mysql_error().'<p><font color=red>'.$sql_a.'</font
 
 $num_a = mysql_num_rows($result_a);
 
-echo '<hr>';
+echo '
+<hr>
+';
 
 for ($i_a=0; $i_a<$num_a; $i_a++) {
 $row_a = mysql_fetch_array($result_a);
@@ -69,7 +71,9 @@ echo '<span title="'.$title.'">'.$row_a['mailsubject'].'</span>';
 
 echo '</span>';
 
-echo '<hr>';
+echo '
+<hr>
+';
 
 }
 

--- a/u5admin/mailnew.php
+++ b/u5admin/mailnew.php
@@ -1,21 +1,25 @@
-<?php 
+<?php
+
 require('connect.inc.php');
-$y=trim(mysql_real_escape_string($_GET['y']));
-if($y=='') echo'<script>alert("ERROR: No new mailjob started because subject empty.");location.href="mailinglist.php"</script>';
-else {
-$sql_a="INSERT INTO mailing (mailsubject,mailsavedop,mailto,mailcc,mailbcc,mailtext,mailsaved,mailsent,mailsentop,maildeleted,mailsentto,mailsentts,mailtested) VALUES ('$y','".mysql_real_escape_string($_SERVER['PHP_AUTH_USER'].' '.$_SERVER['REMOTE_ADDR'])."','','','','',0,0,'',0,'','',0)";
-$result_a=mysql_query($sql_a);
 
-if ($result_a==false) die('SQL_a-Query failed!<p>'.mysql_error().'<p><font color=red>'.$sql_a.'</font><p>');
-$id = mysql_insert_id();
+$convmap = array(0x0100, 0xFFFF, 0, 0xFFFF);
+$encoded_utf8 = mb_encode_numericentity($_GET['y'], $convmap, 'UTF-8');
+$encoded_latin1 = utf8_decode($encoded_utf8);
+$y=trim(mysql_real_escape_string($encoded_latin1));
 
-trxlog("new mj $id");
+if ($y=='') {
+    echo'<script>alert("ERROR: No new mailjob started because subject empty.");location.href="mailinglist.php"</script>';
+} else {
+    $sql_a="INSERT INTO mailing (mailsubject,mailsavedop,mailto,mailcc,mailbcc,mailtext,mailsaved,mailsent,mailsentop,maildeleted,mailsentto,mailsentts,mailtested) VALUES ('$y','".mysql_real_escape_string($_SERVER['PHP_AUTH_USER'].' '.$_SERVER['REMOTE_ADDR'])."','','','','',0,0,'',0,'','',0)";
+    $result_a=mysql_query($sql_a);
 
-echo '<script>
-parent.me.location.href="mailingeditor.php?n='.$_GET['n'].'&id='.$id.'&t='.$_GET['t'].'";
+    if ($result_a==false) die('SQL_a-Query failed!<p>'.mysql_error().'<p><font color=red>'.$sql_a.'</font><p>');
+    $id = mysql_insert_id();
 
-location.href="mailinglist.php?n='.$_GET['n'].'&t='.$_GET['t'].'";
+    trxlog("new mj $id");
 
-</script>';
+    echo '<script>
+          parent.me.location.href="mailingeditor.php?n='.$_GET['n'].'&id='.$id.'&t='.$_GET['t'].'";
+          location.href="mailinglist.php?n='.$_GET['n'].'&t='.$_GET['t'].'";
+          </script>';
 }
-?>


### PR DESCRIPTION
Previously the subject read with prompt() was not correctly in
javascript when sending it as a GET param to the backend. This resulted
in an empty string.

The subject is now correctly urlencoded using encodeURIComponent on the
javascript side, which sends an enoded utf-8 string. On the PHP side the
utf-8 string is then encoded using mb_encode_numericentity() and then
converted to latin1 using utf8_decode().

Fixes #33

![preview](https://user-images.githubusercontent.com/292256/147749791-5533c958-b238-4d0d-bb90-197e7146c76a.jpg)
