### PR TITLE
Remove version number from generator commennt in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ if(parent.window.name==\'i2\')document.getElementById(\'fu5prvldd\').src=\'index
    }
 
 else $template = str_replace('</html>','',str_replace('</body>','<div id="u5clkycrnr" style="width:30px;height:30px;position:absolute;top:0;left:0;z-index:999;" onclick="if (typeof clickycorner === \'undefined\') clickycorner=0;clickycorner++;if(clickycorner>1){window.open(\'edit.php?n='.htmlspecialchars($_GET['n']).'&c='.htmlspecialchars($_GET['c']).'&l='.htmlspecialchars($_GET['l']).'\');clickycorner=0}"><img src="clickycorner.gif" /></div>',$template)).'</body>
-<!-- This site runs in u5CMS V8.3.5. Get u5CMS for free at http://www.yuba.ch/u5cms -->
+<!-- This site is built with the u5CMS. Get it for free at http://www.yuba.ch/u5cms -->
 </html>';
 
 $i_i_item=explode('{{{',$template);


### PR DESCRIPTION
Removing the version number as this is something that will definitely get
forgotten the next time again. The name of the CMS and a link to product is
sufficient IMHO.

Fixes #35
