### PR TITLE
Fix transport of SAML attribute transport in cookie

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -3,9 +3,11 @@ require('connect.inc.php');
 setcookie('u', '', 0, '/', '', $httpsisinuse, true);
 setcookie('p', '', 0, '/', '', $httpsisinuse, true);
 if(isset($u5samlsalt)&&$u5samlsalt!='') {
-    setcookie('u5samlusername', '', 0, '/', '', $httpsisinuse, true);
-    setcookie('u5samlnonce', '', 0, '/', '', $httpsisinuse, true);
-    setcookie('u5samlattribs', '', 0, '/', '', $httpsisinuse, true);
+    foreach (array_keys($_COOKIE) as $key) {
+        if (strpos($key, 'u5saml') === 0) {
+            setcookie($key, '', 0, '/', '', $httpsisinuse, true);
+        }
+    }
     header('Location: /saml/logout.php');
     exit;
 }

--- a/saml/login.php
+++ b/saml/login.php
@@ -60,7 +60,9 @@ if ($u5samlmockauth != 'yes') {
 // cookie for later use anywhere in the CMS
 setcookie('u5samlusername', strtolower(trim($samlattribs['emailaddress'])), 0, '/', '', $httpsisinuse, true);
 setcookie('u5samlnonce', $u5samlnonce, 0, '/', '', $httpsisinuse, true);
-setcookie('u5samlattribs', $samlattribs, 0, '/', $httpsisinuse, true);
+foreach ($samlattribs as $attrib => $value) {
+    setcookie('u5saml' . $attrib, $value, 0, '/', $httpsisinuse, true);
+}
 
 // on CMS instance www.flyssi.ch we want an autoenrollment
 // of user as intranet members
@@ -72,7 +74,7 @@ if ($debug) {
     // Print out processed attributes as saved in cookie
     echo "<h3>Attributes saved for the application:</h3>";
     echo "<table>";
-    foreach($samlattribs AS $key => $value){
+    foreach($samlattribs as $key => $value){
         echo "<tr><td>" . $key . "</td><td>" . $value . "</td></tr>";
     }
     echo "</table>";


### PR DESCRIPTION
My assumption that adding an array to a cookie would automatically create a multi-dimensional structure was wrong. Only key/value pairs are allowed in cookies.