### PR TITLE
Fix search for umlauts by specifying encoding

### DIFF
--- a/san.inc.php
+++ b/san.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 function u5stz($that) {
-    return htmlspecialchars($that);
+    return htmlspecialchars($that, ENT_COMPAT | ENT_HTML401, 'ISO-8859-1');
 }
 
 $filterChars = array('\r', '\n', ';', '<', '>', '(', ')');


### PR DESCRIPTION
Fix broken search by adding the correct charset used e.g. latin1