### PR TITLE
Add additional SAML logout path for debugging

### DIFF
--- a/saml/logged_out.php
+++ b/saml/logged_out.php
@@ -1,0 +1,19 @@
+<?php
+
+error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED ^ E_USER_DEPRECATED);
+
+require ('../simplesaml/_include.php');
+
+$state = \SimpleSAML\Auth\State::loadState((string)$_REQUEST['LogoutState'], 'MyLogoutState');
+$ls = $state['saml:sp:LogoutStatus'];
+
+if ($ls['Code'] === 'urn:oasis:names:tc:SAML:2.0:status:Success' && !isset($ls['SubCode'])) {
+    /* Successful logout. */
+    echo("You have been logged out.");
+} else {
+    /* Logout failed. Tell the user to close the browser. */
+    echo("We were unable to log you out of all your sessions. To be completely sure that you are logged out, you need to close your web browser.");
+}
+
+echo "<br /><pre>";
+var_dump($state);

--- a/saml/logout_debug.php
+++ b/saml/logout_debug.php
@@ -17,5 +17,9 @@ require ('../simplesaml/_include.php');
 // resource as set in the authnsources.php in the SimpleSAMLphp
 // configuration.
 $simpleSaml = new \SimpleSAML\Auth\Simple($u5samlsspauthsourcekey);
-$simpleSaml->logout($u5samllogoutresultpage);
+$simpleSaml->logout([
+    'ReturnTo' => 'https://' . $_SERVER['SERVER_NAME'] . '/saml/logged_out.php',
+    'ReturnStateParam' => 'LogoutState',
+    'ReturnStateStage' => 'MyLogoutState',
+]);
 \SimpleSAML\Session::getSessionFromRequest()->cleanup();

--- a/saml/status.php
+++ b/saml/status.php
@@ -19,8 +19,9 @@ require ('../simplesaml/_include.php');
 $simpleSaml = new \SimpleSAML\Auth\Simple($u5samlsspauthsourcekey);
 
 if ($simpleSaml->isAuthenticated()) {
-    echo "You are currently logged in as user" . $_COOKIE['u5samlusername'] . "</h3>";
-    echo "<br/><button onClick=\"window.location.href='logout.php';\">Logout</button>";
+    echo "You are currently logged in as user " . $_COOKIE['u5samlusername'] . "</h3>";
+    echo "<br/><button onClick=\"window.location.href='logout.php';\">Logout (Standard)</button>";
+    echo " <button onClick=\"window.location.href='logout_debug.php';\">Logout (Debug)</button>";
     // We are authenticated, now fetch attributes from response and fill in
     $samlattributes = $simpleSaml->getAttributes();
     
@@ -57,5 +58,6 @@ if ($simpleSaml->isAuthenticated()) {
     echo "</pre>";
 } else {
     echo "No SAML-Session found. You are currently not logged in.";
+    echo "<br/><button onClick=\"window.location.href='login.php?u=" . rawurlencode('/saml/status.php') . "';\">Login</button>";
 }
 


### PR DESCRIPTION
The status page at /saml/status.php now features a login button and a second
logout button when a current SAML session is found. The standard logout button
does the usual logout process while the new debug logout button is using a new
ReturnTo page, which is validating the SAML logout state and printing its
content.
