### PR TITLE
Sanitize filepaths using realpth and filebases

### DIFF
--- a/f.php
+++ b/f.php
@@ -1,7 +1,7 @@
 <?php
 set_time_limit(3600);
 require_once('connect.inc.php');
-$_GET['f']=u5ProhibTravers(str_replace('r/../r/','r/',$_GET['f']));
+$_GET['f']=str_replace('r/../r/','r/',$_GET['f']);
 
 if(!isset($_GET['t'])){
 $t=explode('?t=',$_SERVER['QUERY_STRING']);
@@ -9,17 +9,20 @@ $t=explode('&',$t[1]);
 $t=$t[0];
 }
 
+$filebase = 'r';
 $f = explode('?', $_GET['f']);
 $_GET['f'] = $f[0];
 $f = explode('/', $_GET['f']);
-$f = 'r/' . basename($f[1]) . '/' . basename($_GET['f']);
+$f = $filebase . '/' . basename($f[1]) . '/' . basename($_GET['f']);
+$f=u5ProhibTravers($f, $filebase);
+
 
 if(substr(basename($_GET['f']),0,1)=='.')die('forbidden');
 
 if($usesessioninsteadofbasicauth=='no') {
     if ($t != '' && $_GET['s'] != '') $f .= '?t=' . $t . '&s=' . $_GET['s'];
     else if ($t != '') $f .= '?t=' . $t;
-	header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 	exit;
 }
 
@@ -55,6 +58,6 @@ require('ft.idn.inc.php');
     $s = $_GET['s'] ?? '';
     if ($t != '' && $s != '') $f .= '?t=' . $t . '&s=' . $s;
     else if ($t != '') $f .= '?t=' . $t;
-    header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 }
 ?>

--- a/ff.php
+++ b/ff.php
@@ -7,17 +7,19 @@ $t=explode('&',$t[1]);
 $t=$t[0];
 }
 
+$filebase = 'fileversions';
 $f = explode('?', $_GET['f']);
 $_GET['f'] = $f[0];
 $f = explode('/', $_GET['f']);
-$f = 'fileversions/' . basename($_GET['f']);
+$f = $filebase . '/' . basename($_GET['f']);
+$f=u5ProhibTravers($f, $filebase);
 
 if(substr(basename($_GET['f']),0,1)=='.')die('forbidden');
 
 if($usesessioninsteadofbasicauth=='no') {
     if ($t != '' && $_GET['s'] != '') $f .= '?t=' . $t . '&s=' . $_GET['s'];
     else if ($t != '') $f .= '?t=' . $t;
-	header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 	exit;
 }
 
@@ -53,6 +55,6 @@ require('ft.idn.inc.php');
     $s = $_GET['s'] ?? '';
     if ($t != '' && $s != '') $f .= '?t=' . $t . '&s=' . $s;
     else if ($t != '') $f .= '?t=' . $t;
-    header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 }
 ?>

--- a/fff.php
+++ b/fff.php
@@ -7,17 +7,19 @@ $t=explode('&',$t[1]);
 $t=$t[0];
 }
 
+$filebase = 'fileversions/_dbbackup';
 $f = explode('?', $_GET['f']);
 $_GET['f'] = $f[0];
 $f = explode('/', $_GET['f']);
-$f = 'fileversions/_dbbackup/' . basename($_GET['f']);
+$f = $filebase . '/' . basename($_GET['f']);
+$f=u5ProhibTravers($f, $filebase);
 
 if(substr(basename($_GET['f']),0,1)=='.')die('forbidden');
 
 if($usesessioninsteadofbasicauth=='no') {
     if ($t != '' && $_GET['s'] != '') $f .= '?t=' . $t . '&s=' . $_GET['s'];
     else if ($t != '') $f .= '?t=' . $t;
-	header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 	exit;
 }
 
@@ -53,6 +55,6 @@ require('ffft.idn.inc.php');
     $s = $_GET['s'] ?? '';
     if ($t != '' && $s != '') $f .= '?t=' . $t . '&s=' . $s;
     else if ($t != '') $f .= '?t=' . $t;
-    header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 }
 ?>

--- a/ffff.php
+++ b/ffff.php
@@ -7,17 +7,19 @@ $t=explode('&',$t[1]);
 $t=$t[0];
 }
 
+$filebase = 'fileversions/useruploads';
 $f = explode('?', $_GET['f']);
 $_GET['f'] = $f[0];
 $f = explode('/', $_GET['f']);
-$f = 'fileversions/useruploads/' . basename($_GET['f']);
+$f = $filebase . '/' . basename($_GET['f']);
+$f=u5ProhibTravers($f, $filebase);
 
 if(substr(basename($_GET['f']),0,1)=='.')die('forbidden');
 
 if($usesessioninsteadofbasicauth=='no') {
     if ($t != '' && $_GET['s'] != '') $f .= '?t=' . $t . '&s=' . $_GET['s'];
     else if ($t != '') $f .= '?t=' . $t;
-	header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 	exit;
 }
 
@@ -53,6 +55,6 @@ require('ffft.idn.inc.php');
     $s = $_GET['s'] ?? '';
     if ($t != '' && $s != '') $f .= '?t=' . $t . '&s=' . $s;
     else if ($t != '') $f .= '?t=' . $t;
-    header("Location: $f");
+    header("Location: " . str_replace($_SERVER['DOCUMENT_ROOT'], '', $f));
 }
 ?>

--- a/myfunctions.inc.php
+++ b/myfunctions.inc.php
@@ -27,28 +27,17 @@ function MailTransport($useSmtp, $options) {
     return $transport;
 }
 
-function u5ProhibTravers(string $input): string {
+function u5ProhibTravers(string $input, string $base): string {
     $parts = explode('?', $input, 2);
     $path = $parts[0];
     $query = $parts[1] ?? '';
 
-    do {
-        $last = $path;
-        $path = urldecode($path);
-    } while ($last !== $path);
+    $base = realpath($base);
+    $real = realpath($path);
 
-    $path = preg_replace('/\s+/', '', $path);
-
-    $dotCount = substr_count($path, '.');
-    if ($dotCount > 1) {
-        $lastDot = strrpos($path, '.');
-        $path = str_replace('.', '', $path);
-        $path = substr_replace($path, '.', $lastDot, 0);
+    if ($real === false || strpos($real, $base) !== 0) {
+        return '';
     }
 
-    $path = str_replace(['\\', '//'], '/', $path);
-    $path = preg_replace('#^/+|/+$#', '', $path);
-    $path = preg_replace('#[^a-zA-Z0-9/_\-\!\.]#', '', $path);
-
-    return $query !== '' ? $path . '?' . $query : $path;
+    return $query !== '' ? $real . '?' . $query : $real;
 }

--- a/thumb.php
+++ b/thumb.php
@@ -13,13 +13,16 @@ if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
 // The file you are resizing 
 if (!isset($stdimagequality)) $stdimagequality = 80;
 
+$filebase = 'r';
 $f = explode('?', $_GET['f']);
 $_GET['f'] = $f[0];
 $f = explode('/', $_GET['f']);
-$f = 'r/' . basename($f[1]) . '/' . basename($_GET['f']);
-$f=u5ProhibTravers($f);
+$f = $filebase . '/' . basename($f[1]) . '/' . basename($_GET['f']);
+$f=u5ProhibTravers($f, $filebase);
 
 if(substr(basename($_GET['f']),0,1)=='.')die('forbidden');
+
+if (!file_exists($f)) die('file not found');
 
 if (!isset($_GET['h'])) $_GET['h'] = '';
 if (!isset($_GET['w'])) $_GET['w'] = '';


### PR DESCRIPTION
Previously it was possible to inject an urlencoded string as follows:

    .%20.%20.

This was first reduced to ". . ." and later to "..". As stripping ".."
is now the last action, this would be catched again.

Is now anything else safe again?
